### PR TITLE
Add WebAssembly build script and wrapper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 /.github export-ignore
 *.ppm binary
 /ChangeLog.md conflict-marker-size=8
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ Makefile
 test_yuv*.jpg
 CMakeCache.txt
 CTestTestfile.cmake
+# WebAssembly build artifacts
+wasm/build/
+wasm/*.js
+wasm/*.wasm
+

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -22,8 +22,9 @@ mkdir -p "$BUILD_DIR"
 pushd "$BUILD_DIR" >/dev/null
 
 # Configure and build static libraries (only configure if not already)
+# Configure without PNG support to avoid libpng dependency in Emscripten
 if [ ! -f Makefile ]; then
-  emcmake cmake "$ROOT_DIR" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_TURBOJPEG=ON
+  emcmake cmake "$ROOT_DIR" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_TURBOJPEG=ON -DPNG_SUPPORTED=OFF
 fi
 emmake make -j"$(nproc)"
 

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build mozjpeg for WebAssembly using Emscripten.
+# The resulting module exposes wasm_compress() and wasm_get_progress().
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+pushd "$BUILD_DIR" >/dev/null
+
+# Configure and build static libraries
+emcmake cmake "$ROOT_DIR" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_TURBOJPEG=ON
+emmake make -j"$(nproc)"
+
+# Compile the WebAssembly module with the wrapper
+emcc "$SCRIPT_DIR/mozjpeg_wasm.c" "$ROOT_DIR/tjutil.c" libjpeg.a turbojpeg.a \
+  -I"$ROOT_DIR" -O3 \
+  -s EXPORTED_FUNCTIONS='["_wasm_compress","_wasm_get_progress"]' \
+  -s MODULARIZE=1 -s EXPORT_NAME="MozJPEG" \
+  -o mozjpeg.js
+
+popd >/dev/null
+
+echo "Build artifacts are located in $BUILD_DIR"

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -8,12 +8,23 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="$SCRIPT_DIR/build"
 
-rm -rf "$BUILD_DIR"
+# Locate the Emscripten SDK and source its environment if needed
+EMS_SDK_DIR=${EMS_SDK_DIR:-/home/ubuntu/3rdParty/emsdk}
+if [ -f "$EMS_SDK_DIR/emsdk_env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$EMS_SDK_DIR/emsdk_env.sh" >/dev/null
+else
+  echo "Emscripten SDK not found in $EMS_SDK_DIR" >&2
+  exit 1
+fi
+
 mkdir -p "$BUILD_DIR"
 pushd "$BUILD_DIR" >/dev/null
 
-# Configure and build static libraries
-emcmake cmake "$ROOT_DIR" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_TURBOJPEG=ON
+# Configure and build static libraries (only configure if not already)
+if [ ! -f Makefile ]; then
+  emcmake cmake "$ROOT_DIR" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_TURBOJPEG=ON
+fi
 emmake make -j"$(nproc)"
 
 # Compile the WebAssembly module with the wrapper

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -29,7 +29,7 @@ fi
 emmake make -j"$(nproc)"
 
 # Compile the WebAssembly module with the wrapper
-emcc "$SCRIPT_DIR/mozjpeg_wasm.c" "$ROOT_DIR/tjutil.c" libjpeg.a turbojpeg.a \
+emcc "$SCRIPT_DIR/mozjpeg_wasm.c" "$ROOT_DIR/tjutil.c" libturbojpeg.a libjpeg.a \
   -I"$ROOT_DIR" -O3 \
   -s EXPORTED_FUNCTIONS='["_wasm_compress","_wasm_get_progress"]' \
   -s MODULARIZE=1 -s EXPORT_NAME="MozJPEG" \

--- a/wasm/mozjpeg_wasm.c
+++ b/wasm/mozjpeg_wasm.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "turbojpeg.h"
+
+/*
+ * Simple WebAssembly-friendly wrappers around the TurboJPEG API.
+ * These functions expect that the input file contains an image format
+ * supported by tjLoadImage() (for instance, PNG or BMP.)
+ */
+
+/* Placeholder progress function.  Real applications can wire this into
+ * their own progress callbacks.  Returning 0.0 indicates unknown progress.
+ */
+double wasm_get_progress(void) {
+  return 0.0;
+}
+
+/*
+ * Compress an image file to JPEG.
+ * Returns 1 on success and 0 on failure.  If rate is non-NULL then the
+ * approximate bits-per-pixel of the compressed image is written to *rate.
+ */
+int wasm_compress(const char *infilename, const char *outfilename,
+                  int quality, double *rate) {
+  tjhandle handle = NULL;
+  unsigned char *srcBuf = NULL, *jpegBuf = NULL;
+  unsigned long jpegSize = 0;
+  int width = 0, height = 0, inSubsamp = 0, inColorspace = 0;
+  FILE *outfile = NULL;
+  int retval = 0;
+
+  /* Load the input image into an RGB buffer. */
+  srcBuf = tjLoadImage(infilename, &width, 0, &height, &inColorspace, TJPF_RGB);
+  if (!srcBuf)
+    goto bailout;
+
+  handle = tjInitCompress();
+  if (!handle)
+    goto bailout;
+
+  if (tjCompress2(handle, srcBuf, width, 0, height, TJPF_RGB, &jpegBuf,
+                  &jpegSize, TJSAMP_420, quality, TJFLAG_ACCURATEDCT) < 0)
+    goto bailout;
+
+  outfile = fopen(outfilename, "wb");
+  if (!outfile)
+    goto bailout;
+
+  if (fwrite(jpegBuf, jpegSize, 1, outfile) != 1)
+    goto bailout;
+
+  if (rate)
+    *rate = (double)jpegSize / (double)(width * height * tjPixelSize[TJPF_RGB]) * 8.0;
+
+  retval = 1;  /* Success */
+
+bailout:
+  if (outfile)
+    fclose(outfile);
+  if (jpegBuf)
+    tjFree(jpegBuf);
+  if (srcBuf)
+    tjFree(srcBuf);
+  if (handle)
+    tjDestroy(handle);
+  return retval;
+}


### PR DESCRIPTION
## Summary
- add mozjpeg_wasm.c with simple TurboJPEG-based compression wrapper for WebAssembly
- provide build.sh to compile mozjpeg and wrapper to wasm using Emscripten
- ignore WebAssembly build outputs in git

## Testing
- No tests were run


------
https://chatgpt.com/codex/tasks/task_e_68a0212e5d648330b85616cc9c289a7d