### PR TITLE
Show compression rate in WASM demo

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -3,7 +3,8 @@
 This directory contains a minimal WebAssembly build of MozJPEG using
 [Emscripten](https://emscripten.org/). The build exposes two functions:
 
-- `wasm_compress()` – recompress a JPEG image at the specified quality
+- `wasm_compress()` – recompress a JPEG image at the specified quality and
+  return the fraction of the original file size saved (or -1 on failure)
 - `wasm_get_progress()` – placeholder progress callback
 
 ## Build

--- a/wasm/demo/demo.js
+++ b/wasm/demo/demo.js
@@ -8,6 +8,7 @@ const quality = document.getElementById('quality');
 const qval = document.getElementById('qval');
 const download = document.getElementById('download');
 const preview = document.getElementById('preview');
+const rate = document.getElementById('rate');
 
 quality.addEventListener('input', () => {
   qval.textContent = quality.value;
@@ -43,6 +44,9 @@ document.getElementById('compress').addEventListener('click', async () => {
     download.href = url;
     download.download = dstName;
     download.textContent = `Download JPEG (${Math.round(blob.size / 1024)} kB)`;
+    const ratePercent = (blob.size / file.size) * 100;
+    rate.style.display = 'block';
+    rate.textContent = `Compression rate: ${ratePercent.toFixed(1)}%`;
     preview.src = url;
   } catch (err) {
     console.error('Compression failed:', err);

--- a/wasm/demo/demo.js
+++ b/wasm/demo/demo.js
@@ -29,16 +29,14 @@ document.getElementById('compress').addEventListener('click', async () => {
   try {
     module.FS.writeFile(srcName, new Uint8Array(arrayBuffer));
 
-    const ratePtr = module._malloc(8);
-    const res = module.ccall(
+    const savedFraction = module.ccall(
       'wasm_compress',
       'number',
-      ['string', 'string', 'number', 'number'],
-      [srcName, dstName, parseInt(quality.value, 10), ratePtr]
+      ['string', 'string', 'number'],
+      [srcName, dstName, parseInt(quality.value, 10)]
     );
-    if (!res) throw new Error('wasm_compress returned 0');
-    const savedFraction = module.HEAPF64[ratePtr / 8];
-    module._free(ratePtr);
+    if (savedFraction < 0)
+      throw new Error('wasm_compress failed');
 
     const out = module.FS.readFile(dstName);
     const blob = new Blob([out], { type: 'image/jpeg' });

--- a/wasm/demo/index.html
+++ b/wasm/demo/index.html
@@ -19,6 +19,7 @@
   </label>
   <button id="compress">Compress</button>
   <p><a id="download" style="display:none"></a></p>
+  <p id="rate" style="display:none"></p>
   <img id="preview" alt="Compressed preview" />
 
   <script src="mozjpeg.js"></script>

--- a/wasm/mozjpeg_wasm.c
+++ b/wasm/mozjpeg_wasm.c
@@ -17,7 +17,8 @@ double wasm_get_progress(void) {
 /*
  * Recompress a JPEG file with a new quality setting.
  * Returns 1 on success and 0 on failure.  If rate is non-NULL then the
- * approximate bits-per-pixel of the compressed image is written to *rate.
+ * fraction of the original file size saved by compression is written to
+ * *rate.
  */
 int wasm_compress(const char *infilename, const char *outfilename,
                   int quality, double *rate) {
@@ -73,8 +74,8 @@ int wasm_compress(const char *infilename, const char *outfilename,
   if (fwrite(jpegBuf, jpegSize, 1, outfile) != 1)
     goto bailout;
   if (rate)
-    *rate = (double)jpegSize /
-            (double)(width * height * tjPixelSize[TJPF_RGB]) * 8.0;
+    *rate = (jpegSize >= inSize) ? 0.0 :
+            (double)(inSize - jpegSize) / (double)inSize;
 
   retval = 1; /* Success */
 

--- a/wasm/mozjpeg_wasm.c
+++ b/wasm/mozjpeg_wasm.c
@@ -16,19 +16,18 @@ double wasm_get_progress(void) {
 
 /*
  * Recompress a JPEG file with a new quality setting.
- * Returns 1 on success and 0 on failure.  If rate is non-NULL then the
- * fraction of the original file size saved by compression is written to
- * *rate.
+ * Returns the fraction of the original file size saved by compression, or
+ * -1 on failure.
  */
-int wasm_compress(const char *infilename, const char *outfilename,
-                  int quality, double *rate) {
+double wasm_compress(const char *infilename, const char *outfilename,
+                     int quality) {
   tjhandle dhandle = NULL, chandle = NULL;
   unsigned char *inBuf = NULL, *rgbBuf = NULL, *jpegBuf = NULL;
   unsigned long jpegSize = 0;
   size_t inSize = 0;
   int width = 0, height = 0, subsamp = 0;
   FILE *infile = NULL, *outfile = NULL;
-  int retval = 0;
+  double rate = -1.0;
 
   infile = fopen(infilename, "rb");
   if (!infile)
@@ -73,14 +72,11 @@ int wasm_compress(const char *infilename, const char *outfilename,
     goto bailout;
   if (fwrite(jpegBuf, jpegSize, 1, outfile) != 1)
     goto bailout;
-  if (rate)
-    *rate = (jpegSize >= inSize) ? 0.0 :
-            (double)(inSize - jpegSize) / (double)inSize;
-
-  retval = 1; /* Success */
+  rate = (jpegSize >= inSize) ? 0.0 :
+         (double)(inSize - jpegSize) / (double)inSize;
 
 bailout:
-  if (!retval) {
+  if (rate < 0.0) {
     const char *err = chandle ? tjGetErrorStr2(chandle)
                               : (dhandle ? tjGetErrorStr2(dhandle)
                                          : tjGetErrorStr());
@@ -100,5 +96,5 @@ bailout:
     tjDestroy(dhandle);
   if (infile)
     fclose(infile);
-  return retval;
+  return rate;
 }


### PR DESCRIPTION
## Summary
- display compression rate percentage after browser recompression

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a0fa6e2f708330819529c76984ad8c